### PR TITLE
Move image stack scaling to `ImageStackWidget`

### DIFF
--- a/mapclientplugins/autosegmentationstep/qt/autosegmentationwidget.ui
+++ b/mapclientplugins/autosegmentationstep/qt/autosegmentationwidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>820</width>
-    <height>781</height>
+    <height>878</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -32,9 +32,6 @@
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
            <spacer name="horizontalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
-            </property>
             <property name="sizeHint" stdset="0">
              <size>
               <width>20</width>
@@ -49,7 +46,7 @@
              <number>6</number>
             </property>
             <property name="sizeConstraint">
-             <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+             <enum>QLayout::SetDefaultConstraint</enum>
             </property>
             <property name="leftMargin">
              <number>10</number>
@@ -80,21 +77,15 @@
               <property name="text">
                <string>Image Plane Level</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignmentFlag::AlignCenter</set>
-              </property>
               <property name="wordWrap">
                <bool>true</bool>
               </property>
              </widget>
             </item>
-            <item alignment="Qt::AlignmentFlag::AlignHCenter">
+            <item>
              <widget class="QSlider" name="isoValueSlider">
               <property name="maximum">
                <number>99</number>
-              </property>
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
               </property>
              </widget>
             </item>
@@ -109,9 +100,6 @@
           </item>
           <item>
            <spacer name="horizontalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
-            </property>
             <property name="sizeHint" stdset="0">
              <size>
               <width>20</width>
@@ -145,21 +133,15 @@
               <property name="text">
                <string>Segmentation Contour Threshold</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignmentFlag::AlignCenter</set>
-              </property>
               <property name="wordWrap">
                <bool>true</bool>
               </property>
              </widget>
             </item>
-            <item alignment="Qt::AlignmentFlag::AlignHCenter">
+            <item>
              <widget class="QSlider" name="segmentationValueSlider">
               <property name="maximum">
                <number>10000</number>
-              </property>
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
               </property>
              </widget>
             </item>
@@ -174,9 +156,6 @@
           </item>
           <item>
            <spacer name="horizontalSpacer_5">
-            <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
-            </property>
             <property name="sizeHint" stdset="0">
              <size>
               <width>20</width>
@@ -186,46 +165,6 @@
            </spacer>
           </item>
          </layout>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="groupBoxImage">
-          <property name="title">
-           <string>Image</string>
-          </property>
-          <layout class="QFormLayout" name="formLayout_2">
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_7">
-             <property name="text">
-              <string>Dimensions:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLabel" name="imagePixelOutputLabel">
-             <property name="text">
-              <string>AxBxC px</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QCheckBox" name="overrideScalingCheckBox">
-             <property name="text">
-              <string>Override pre-dertermined scaling</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="1">
-            <widget class="QLineEdit" name="scalingLineEdit"/>
-           </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="label_6">
-             <property name="text">
-              <string>Scaling:</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
         </item>
         <item>
          <widget class="QGroupBox" name="groupBoxSegmentation">
@@ -456,9 +395,6 @@ The segmentation contour will have to be very close
       </item>
       <item>
        <spacer name="horizontalSpacer_4">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
         <property name="sizeHint" stdset="0">
          <size>
           <width>10</width>
@@ -498,9 +434,6 @@ The segmentation contour will have to be very close
      </item>
      <item>
       <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
-       </property>
        <property name="sizeHint" stdset="0">
         <size>
          <width>40</width>

--- a/mapclientplugins/autosegmentationstep/widgets/autosegmentationwidget.py
+++ b/mapclientplugins/autosegmentationstep/widgets/autosegmentationwidget.py
@@ -20,6 +20,7 @@ from cmlibs.utils.zinc.mesh import find_connected_mesh_elements_0d
 from cmlibs.widgets.handlers.scenemanipulation import SceneManipulation
 from cmlibs.widgets.handlers.orientation import Orientation
 from cmlibs.widgets.handlers.fixedaxistranslation import FixedAxisTranslation
+from cmlibs.widgets.imagestackwidget import ImageStackWidget
 
 from mapclientplugins.autosegmentationstep.model.autosegmentationmodel import AutoSegmentationModel
 from mapclientplugins.autosegmentationstep.scene.autosegmentationscene import AutoSegmentationScene
@@ -69,9 +70,8 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
         self._view.register_handler(normal_handler)
 
         self._setup_tessellation_line_edit()
-        self._set_scale_validator()
-        display_dimensions = ", ".join([f"{d}" for d in self._model.get_dimensions()])
-        self._ui.imagePixelOutputLabel.setText(f"{display_dimensions} px")
+        self._image_stack_widget = ImageStackWidget(self._model.get_dimensions())
+        self._ui.verticalLayout_3.insertWidget(1, self._image_stack_widget)
 
         self._make_connections()
         self._ui.comboBoxConnectedSurfaces.setEnabled(self._ui.checkBoxToggleDetection.isChecked())
@@ -83,7 +83,6 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
         self._ui.segmentationValueSlider.valueChanged.connect(self._set_line_edit_value)
         self._ui.tessellationDivisionsLineEdit.editingFinished.connect(self._update_tessellation)
         self._ui.pointSizeLineEdit.editingFinished.connect(self._update_point_size)
-        self._ui.scalingLineEdit.editingFinished.connect(self._update_scale)
         self._ui.allowHighTessellationsCheckBox.stateChanged.connect(self._set_tessellation_validator)
         self._ui.imagePlaneCheckBox.stateChanged.connect(self._scene.set_image_plane_visibility)
         self._ui.segmentationCheckBox.stateChanged.connect(self._scene.set_segmentation_visibility)
@@ -99,6 +98,7 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
         self._ui.doneButton.clicked.connect(self._done_execution)
         self._ui.comboBoxConnectedSurfaces.currentIndexChanged.connect(self._connected_subgroup_changed)
         self._ui.checkBoxTargetSpecificValue.stateChanged.connect(self._target_specific_value_changed)
+        self._image_stack_widget.scale_updated.connect(self._update_scale)
 
     def register_done_execution(self, done_execution):
         self._callback = done_execution
@@ -251,8 +251,8 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
         self._ui.outlineCheckBox.setChecked(settings.get("outline", True))
         self._ui.segmentationAlphaDoubleSpinBox.setValue(settings.get("alpha", 1.0))
         self._ui.allowHighTessellationsCheckBox.setChecked(settings.get("tessellation-override", False))
-        self._ui.overrideScalingCheckBox.setChecked(settings.get("scaling-override", False))
-        self._ui.scalingLineEdit.setText(settings.get("scaling", "1, 1, 1"))
+        self._image_stack_widget.override_scaling(settings.get("scaling-override", False))
+        self._image_stack_widget.set_scaling(settings.get("scaling", "1, 1, 1"))
         self._ui.segmentationMeshAlphaDoubleSpinBox.setValue(settings.get("mesh-alpha", 1.0))
         self._ui.detectionPlaneAlphaDoubleSpinBox.setValue(settings.get("plane-alpha", 1.0))
         self._ui.checkBoxTargetSpecificValue.setChecked(settings.get("target-specific", False))
@@ -271,7 +271,7 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
             self._model.get_output_region().readFile(self.get_output_filename())
 
         self._update_point_size()
-        self._update_scale()
+        self._image_stack_widget.update_scale()
 
     def _save_settings(self):
         if not os.path.exists(self._location):
@@ -288,8 +288,8 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
             "tessellation": self._ui.tessellationDivisionsLineEdit.text(),
             "alpha": self._ui.segmentationAlphaDoubleSpinBox.value(),
             "tessellation-override": self._ui.allowHighTessellationsCheckBox.isChecked(),
-            "scaling-override": self._ui.overrideScalingCheckBox.isChecked(),
-            "scaling": self._ui.scalingLineEdit.text(),
+            "scaling-override": self._image_stack_widget.scaling_overridden(),
+            "scaling": self._image_stack_widget.get_scaling(),
             "point-density": self._ui.pointDensityLineEdit.text(),
             "point-size": self._ui.pointSizeLineEdit.text(),
             "mesh-alpha": self._ui.segmentationMeshAlphaDoubleSpinBox.value(),
@@ -325,10 +325,6 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
 
         self._set_tessellation_validator()
 
-    def _set_scale_validator(self):
-        regex = QtCore.QRegularExpression("^[0-9.]+((, ?[0-9.]+){2})?$")
-        _set_vector_validator(self._ui.scalingLineEdit, regex)
-
     def _set_tessellation_validator(self):
         size = 5 if self._ui.allowHighTessellationsCheckBox else 3
         regex = QtCore.QRegularExpression(f"^[0-9]{{1,{size}}}((, ?[0-9]{{1,{size}}}){{2}})?$")
@@ -350,12 +346,9 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
         if size:
             self._scene.set_point_size(float(size))
 
-    def _update_scale(self):
-        text = self._ui.scalingLineEdit.text()
-        if text:
-            scale = [float(x.strip()) for x in text.split(',')]
-            self._model.set_scale(scale)
-            self._scene.update_scale()
+    def _update_scale(self, scale):
+        self._model.set_scale(scale)
+        self._scene.update_scale()
 
     def _generate_points(self):
         self._scene.set_image_plane_visibility(0)

--- a/mapclientplugins/autosegmentationstep/widgets/ui_autosegmentationwidget.py
+++ b/mapclientplugins/autosegmentationstep/widgets/ui_autosegmentationwidget.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'autosegmentationwidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.5.2
+## Created by: Qt User Interface Compiler version 6.5.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -27,7 +27,7 @@ class Ui_AutoSegmentationWidget(object):
     def setupUi(self, AutoSegmentationWidget):
         if not AutoSegmentationWidget.objectName():
             AutoSegmentationWidget.setObjectName(u"AutoSegmentationWidget")
-        AutoSegmentationWidget.resize(820, 781)
+        AutoSegmentationWidget.resize(820, 878)
         self.verticalLayout = QVBoxLayout(AutoSegmentationWidget)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.groupBox = QGroupBox(AutoSegmentationWidget)
@@ -50,7 +50,7 @@ class Ui_AutoSegmentationWidget(object):
         self.verticalLayout_5 = QVBoxLayout()
         self.verticalLayout_5.setSpacing(6)
         self.verticalLayout_5.setObjectName(u"verticalLayout_5")
-        self.verticalLayout_5.setSizeConstraint(QLayout.SizeConstraint.SetDefaultConstraint)
+        self.verticalLayout_5.setSizeConstraint(QLayout.SetDefaultConstraint)
         self.verticalLayout_5.setContentsMargins(10, -1, 10, -1)
         self.label = QLabel(self.groupBox)
         self.label.setObjectName(u"label")
@@ -61,7 +61,6 @@ class Ui_AutoSegmentationWidget(object):
         self.label.setSizePolicy(sizePolicy1)
         self.label.setMinimumSize(QSize(80, 26))
         self.label.setMaximumSize(QSize(80, 26))
-        self.label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.label.setWordWrap(True)
 
         self.verticalLayout_5.addWidget(self.label)
@@ -69,9 +68,8 @@ class Ui_AutoSegmentationWidget(object):
         self.isoValueSlider = QSlider(self.groupBox)
         self.isoValueSlider.setObjectName(u"isoValueSlider")
         self.isoValueSlider.setMaximum(99)
-        self.isoValueSlider.setOrientation(Qt.Orientation.Vertical)
 
-        self.verticalLayout_5.addWidget(self.isoValueSlider, 0, Qt.AlignmentFlag.AlignHCenter)
+        self.verticalLayout_5.addWidget(self.isoValueSlider)
 
         self.isoValueLineEdit = QLineEdit(self.groupBox)
         self.isoValueLineEdit.setObjectName(u"isoValueLineEdit")
@@ -97,7 +95,6 @@ class Ui_AutoSegmentationWidget(object):
         self.label_2.setSizePolicy(sizePolicy2)
         self.label_2.setMinimumSize(QSize(100, 26))
         self.label_2.setMaximumSize(QSize(100, 26))
-        self.label_2.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.label_2.setWordWrap(True)
 
         self.verticalLayout_4.addWidget(self.label_2)
@@ -105,9 +102,8 @@ class Ui_AutoSegmentationWidget(object):
         self.segmentationValueSlider = QSlider(self.groupBox)
         self.segmentationValueSlider.setObjectName(u"segmentationValueSlider")
         self.segmentationValueSlider.setMaximum(10000)
-        self.segmentationValueSlider.setOrientation(Qt.Orientation.Vertical)
 
-        self.verticalLayout_4.addWidget(self.segmentationValueSlider, 0, Qt.AlignmentFlag.AlignHCenter)
+        self.verticalLayout_4.addWidget(self.segmentationValueSlider)
 
         self.segmentationValueLineEdit = QLineEdit(self.groupBox)
         self.segmentationValueLineEdit.setObjectName(u"segmentationValueLineEdit")
@@ -124,38 +120,6 @@ class Ui_AutoSegmentationWidget(object):
 
 
         self.verticalLayout_3.addLayout(self.horizontalLayout_2)
-
-        self.groupBoxImage = QGroupBox(self.groupBox)
-        self.groupBoxImage.setObjectName(u"groupBoxImage")
-        self.formLayout_2 = QFormLayout(self.groupBoxImage)
-        self.formLayout_2.setObjectName(u"formLayout_2")
-        self.label_7 = QLabel(self.groupBoxImage)
-        self.label_7.setObjectName(u"label_7")
-
-        self.formLayout_2.setWidget(0, QFormLayout.LabelRole, self.label_7)
-
-        self.imagePixelOutputLabel = QLabel(self.groupBoxImage)
-        self.imagePixelOutputLabel.setObjectName(u"imagePixelOutputLabel")
-
-        self.formLayout_2.setWidget(0, QFormLayout.FieldRole, self.imagePixelOutputLabel)
-
-        self.overrideScalingCheckBox = QCheckBox(self.groupBoxImage)
-        self.overrideScalingCheckBox.setObjectName(u"overrideScalingCheckBox")
-
-        self.formLayout_2.setWidget(2, QFormLayout.FieldRole, self.overrideScalingCheckBox)
-
-        self.scalingLineEdit = QLineEdit(self.groupBoxImage)
-        self.scalingLineEdit.setObjectName(u"scalingLineEdit")
-
-        self.formLayout_2.setWidget(3, QFormLayout.FieldRole, self.scalingLineEdit)
-
-        self.label_6 = QLabel(self.groupBoxImage)
-        self.label_6.setObjectName(u"label_6")
-
-        self.formLayout_2.setWidget(3, QFormLayout.LabelRole, self.label_6)
-
-
-        self.verticalLayout_3.addWidget(self.groupBoxImage)
 
         self.groupBoxSegmentation = QGroupBox(self.groupBox)
         self.groupBoxSegmentation.setObjectName(u"groupBoxSegmentation")
@@ -364,11 +328,6 @@ class Ui_AutoSegmentationWidget(object):
         self.groupBox.setTitle(QCoreApplication.translate("AutoSegmentationWidget", u"Auto Segmentation Viewer", None))
         self.label.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Image Plane Level", None))
         self.label_2.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Segmentation Contour Threshold", None))
-        self.groupBoxImage.setTitle(QCoreApplication.translate("AutoSegmentationWidget", u"Image", None))
-        self.label_7.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Dimensions:", None))
-        self.imagePixelOutputLabel.setText(QCoreApplication.translate("AutoSegmentationWidget", u"AxBxC px", None))
-        self.overrideScalingCheckBox.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Override pre-dertermined scaling", None))
-        self.label_6.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Scaling:", None))
         self.groupBoxSegmentation.setTitle(QCoreApplication.translate("AutoSegmentationWidget", u"Segmentation", None))
 #if QT_CONFIG(tooltip)
         self.allowHighTessellationsCheckBox.setToolTip(QCoreApplication.translate("AutoSegmentationWidget", u"High tessellations are turned off by default because it may take the contour\n"


### PR DESCRIPTION
The image stack scaling should now be handled by the `cmlibs.widgets` `ImageStackWidget`.

This PR depends on [CMLibs-Widgets PR 82](https://github.com/cmlibs-python/cmlibs.widgets/pull/82).